### PR TITLE
Add do_not_enforce_on_create to resource_github_organization_ruleset …

### DIFF
--- a/github/resource_github_organization_ruleset.go
+++ b/github/resource_github_organization_ruleset.go
@@ -256,6 +256,11 @@ func resourceGithubOrganizationRuleset() *schema.Resource {
 											},
 										},
 									},
+									"do_not_enforce_on_create": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: "Allow repositories and branches to be created if a check would otherwise prohibit it.",
+									},
 									"strict_required_status_checks_policy": {
 										Type:        schema.TypeBool,
 										Optional:    true,

--- a/github/resource_github_organization_ruleset_test.go
+++ b/github/resource_github_organization_ruleset_test.go
@@ -60,6 +60,7 @@ func TestGithubOrganizationRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
+						do_not_enforce_on_create			 = true
 					}
 
 					required_workflows {

--- a/github/resource_github_repository_ruleset.go
+++ b/github/resource_github_repository_ruleset.go
@@ -244,6 +244,11 @@ func resourceGithubRepositoryRuleset() *schema.Resource {
 											},
 										},
 									},
+									"do_not_enforce_on_create": {
+										Type:        schema.TypeBool,
+										Optional:    true,
+										Description: "Allow repositories and branches to be created if a check would otherwise prohibit it.",
+									},
 									"strict_required_status_checks_policy": {
 										Type:        schema.TypeBool,
 										Optional:    true,

--- a/github/resource_github_repository_ruleset_test.go
+++ b/github/resource_github_repository_ruleset_test.go
@@ -70,6 +70,7 @@ func TestGithubRepositoryRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
+						do_not_enforce_on_create             = true
 					}
 
 					non_fast_forward = true
@@ -319,6 +320,7 @@ func TestGithubRepositoryRulesets(t *testing.T) {
 						}
 
 						strict_required_status_checks_policy = true
+						do_not_enforce_on_create             = true
 					}
 
 					non_fast_forward = true

--- a/github/respository_rules_utils.go
+++ b/github/respository_rules_utils.go
@@ -325,6 +325,7 @@ func expandRules(input []interface{}, org bool) []*github.RepositoryRule {
 		}
 
 		params := &github.RequiredStatusChecksRuleParameters{
+			DoNotEnforceOnCreate:             requiredStatusMap["do_not_enforce_on_create"].(bool),
 			RequiredStatusChecks:             requiredStatusChecks,
 			StrictRequiredStatusChecksPolicy: requiredStatusMap["strict_required_status_checks_policy"].(bool),
 		}
@@ -501,6 +502,7 @@ func flattenRules(rules []*github.RepositoryRule, org bool) []interface{} {
 			}
 
 			rule := make(map[string]interface{})
+			rule["do_not_enforce_on_create"] = params.DoNotEnforceOnCreate
 			rule["required_check"] = requiredStatusChecksSlice
 			rule["strict_required_status_checks_policy"] = params.StrictRequiredStatusChecksPolicy
 			rulesMap[v.Type] = []map[string]interface{}{rule}

--- a/website/docs/r/repository_ruleset.html.markdown
+++ b/website/docs/r/repository_ruleset.html.markdown
@@ -171,6 +171,8 @@ The `rules` block supports the following:
 
 #### rules.required_status_checks ####
 
+* `do_not_enforce_on_create` - (Optional) (Boolean) Allow repositories and branches to be created if a check would otherwise prohibit it. Defaults to `false`.
+
 * `required_check` - (Required) (Block Set, Min: 1) Status checks that are required. Several can be defined. (see [below for nested schema](#rules.required_status_checks.required_check))
 
 * `strict_required_status_checks_policy` - (Optional) (Boolean) Whether pull requests targeting a matching branch must be tested with the latest code. This setting will not take effect unless at least one status check is enabled. Defaults to `false`.


### PR DESCRIPTION
Optional attribute added to rules.required_status_checks.
Resolves #2360

----

### Before the change?

* The option to allow repositories and branches to be created without enforcing status checks were prohibited by default, and would substitute the value of this configuration from the repo to always be false. It was not available for repository and organization rulesets.

### After the change?

* Now it has the option to disable enforce status checks on creation of a new branch/repo, manageable through the provider and do not overwriting the configuration in the ruleset without being shown in terraform plan/apply.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
- [ ] Yes
- [x] No

----
